### PR TITLE
Cross-VLAN speaker discovery, optional dashboard password, faster startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ payload/
 # Local build/install logs -- machine-specific, not useful to anyone else
 install-log.txt
 installer-build-log.txt
+
+# Dashboard password -- lives in %ProgramData%\PC2Sonos at runtime, never
+# in the repo; ignored here too so a dev-time copy can't be committed
+dashboard_password.txt

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ installer-build-log.txt
 # Dashboard password -- lives in %ProgramData%\PC2Sonos at runtime, never
 # in the repo; ignored here too so a dev-time copy can't be committed
 dashboard_password.txt
+
+# Local Python virtual environments
+venv/
+.venv/
+env/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,28 @@ idea as the "audio delay" / lip-sync offset setting on an AV receiver.
 
 After that, it's fully automatic: log into Windows, PC2Sonos starts
 quietly in the system tray, and every Sonos speaker you enabled starts
-receiving audio.
+receiving audio. The dashboard opens in your browser on the very first
+run only; after that a small tray notification just confirms it started,
+and the dashboard is one click away on the tray icon.
+
+### Optional: start faster after a reboot
+
+Normally PC2Sonos runs a network scan at startup to find your speakers,
+which takes 15-20 seconds before audio begins. If you mostly stream to
+one speaker, click the **&#9733;** next to it in the dashboard to make it
+the *default speaker*: PC2Sonos then talks to that speaker directly at
+launch and starts playing in a second or two, and the full scan happens
+in the background. Give that speaker a DHCP reservation in your router so
+its address doesn't change.
+
+To go further, set `"discovery_mode": "on_demand"` in `config.json`: once
+the default speaker is up, the repeating background scan stops entirely
+(it runs once as a safety net, then only when you press **Rescan**).
+
+By default a newly-discovered speaker starts out enabled (a fresh install
+lights up everything and you turn off what you don't want). Set
+`"new_speakers_default_enabled": false` in `config.json` to have new
+speakers stay off until you enable them -- handy on a busy network.
 
 ### Optional: password-protect the dashboard
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ After that, it's fully automatic: log into Windows, PC2Sonos starts
 quietly in the system tray, and every Sonos speaker you enabled starts
 receiving audio.
 
+### Optional: password-protect the dashboard
+
+By default the dashboard has no password -- PC2Sonos assumes it's running
+on a network you control.
+
+To require one, create a file named `dashboard_password.txt` in the
+PC2Sonos data folder -- the same folder that holds `config.json` and
+`pc2sonos.log` (its full path is printed at the top of `pc2sonos.log`
+every time the app starts; on a normal install it's
+`%ProgramData%\PC2Sonos`). Put the password on the first line and save.
+
+It takes effect on the next page load -- the browser will ask for a
+username (anything works) and the password. Delete the file to remove the
+password again.
+
+What this is and isn't: it's a low-effort gate to keep other people on
+the same LAN (housemates, guests on the wifi) from opening the dashboard
+and toggling your speakers or changing settings. It is **not** strong
+security. The password sits in a plain text file, it's sent over plain
+HTTP (base64-encoded, not encrypted -- anyone who can capture traffic on
+your network can read it), and the audio stream endpoint stays open
+because Sonos speakers can't authenticate. Don't reuse a password you
+care about, and don't rely on this if the dashboard is somehow reachable
+from outside your home network. The file is deliberately kept out of the
+diagnostics export so it isn't shared by accident.
+
 ## Running from source (for development)
 
 The steps above are what an end user needs -- nothing else. This section

--- a/audio_engine.py
+++ b/audio_engine.py
@@ -169,7 +169,10 @@ def get_lan_ip():
     different NICs with different IPs. Ask the routing table which
     source IP it would use to reach an actual speaker first, and only
     fall back to the internet-facing IP when we don't know one yet."""
-    targets = list(config.get("sonos_seed_ips") or [])
+    targets = []
+    if config.get("default_speaker_ip"):
+        targets.append(config["default_speaker_ip"])
+    targets += list(config.get("sonos_seed_ips") or [])
     try:
         from sonos_ctl import speaker_mgr
         targets += sorted(speaker_mgr._known_ips)

--- a/audio_engine.py
+++ b/audio_engine.py
@@ -147,16 +147,44 @@ def get_pyaudio():
     return _pa
 
 
-def get_lan_ip():
+def _source_ip_for(target):
+    """The local IP the OS would use as the source address to reach
+    `target`. No packet is actually sent -- connect() on a UDP socket
+    just does the route lookup."""
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(("8.8.8.8", 80))
-        ip = s.getsockname()[0]
-    except Exception:
-        ip = "127.0.0.1"
+        s.connect((target, 80))
+        return s.getsockname()[0]
     finally:
         s.close()
-    return ip
+
+
+def get_lan_ip():
+    """This PC's LAN IP -- the address Sonos speakers fetch the stream
+    from, so it has to be the one reachable FROM the speakers.
+
+    When the speakers sit on another subnet/VLAN and this PC has more
+    than one interface (Wi-Fi + Ethernet, a VPN, Docker, etc.), the
+    route to the internet and the route to the speakers can leave from
+    different NICs with different IPs. Ask the routing table which
+    source IP it would use to reach an actual speaker first, and only
+    fall back to the internet-facing IP when we don't know one yet."""
+    targets = list(config.get("sonos_seed_ips") or [])
+    try:
+        from sonos_ctl import speaker_mgr
+        targets += sorted(speaker_mgr._known_ips)
+    except Exception:
+        pass
+    targets.append("8.8.8.8")
+    for target in targets:
+        target = str(target).strip()
+        if not target:
+            continue
+        try:
+            return _source_ip_for(target)
+        except Exception:
+            continue
+    return "127.0.0.1"
 
 
 def capture_loop(stop_event):

--- a/audio_engine.py
+++ b/audio_engine.py
@@ -175,7 +175,7 @@ def get_lan_ip():
     targets += list(config.get("sonos_seed_ips") or [])
     try:
         from sonos_ctl import speaker_mgr
-        targets += sorted(speaker_mgr._known_ips)
+        targets += speaker_mgr.known_ips()
     except Exception:
         pass
     targets.append("8.8.8.8")

--- a/config.py
+++ b/config.py
@@ -20,6 +20,14 @@ from pathlib import Path
 APP_DIR = Path(os.environ.get("ProgramData", r"C:\ProgramData")) / "PC2Sonos"
 CONFIG_PATH = APP_DIR / "config.json"
 
+# Optional dashboard password. Kept in its own file, NOT in config.json,
+# on purpose: config.json is bundled verbatim into the diagnostics zip
+# (see diagnostics.export_diagnostics_zip) that users email to support --
+# a password in there would ride along in every submission. This file is
+# never read by diagnostics and is git-ignored. One line of plain text;
+# if the file is missing or empty the dashboard has no password.
+PASSWORD_PATH = APP_DIR / "dashboard_password.txt"
+
 # Every location this data has lived in before, oldest first -- checked in
 # order so an upgrade from ANY prior version carries the existing config
 # forward instead of silently starting over.

--- a/config.py
+++ b/config.py
@@ -109,6 +109,31 @@ DEFAULT_CONFIG = {
     # gets a unicast port-1400 sweep when no seed is reachable.
     "sonos_seed_ips": [],
     "sonos_scan_cidrs": [],
+    # Startup behavior -----------------------------------------------------
+    # default_speaker_ip: if set, PC2Sonos talks to this one speaker
+    # directly at launch instead of waiting for a discovery pass -- audio
+    # starts in ~1-2s instead of ~15-20s. Give that speaker a DHCP
+    # reservation. default_speaker_uid is filled in automatically the
+    # first time we reach it, and is then used to notice if DHCP later
+    # hands that IP to a different device (in which case the IP is
+    # ignored and normal discovery takes over). Blank = today's behavior.
+    "default_speaker_ip": "",
+    "default_speaker_uid": "",
+    # "auto" = keep re-scanning the network every 15s in the background.
+    # "on_demand" = once the default speaker is up, stop the background
+    # loop; only re-scan at startup and when the dashboard asks. Useful
+    # if you only ever stream to the one speaker.
+    "discovery_mode": "auto",
+    # When a brand-new speaker is discovered, start streaming to it right
+    # away (true, the default -- a fresh install lights up every speaker
+    # and you turn off the ones you don't want) or leave it off until you
+    # enable it in the dashboard (false). The default speaker is always
+    # enabled regardless.
+    "new_speakers_default_enabled": True,
+    # Flipped to true after the app's first successful launch. While
+    # false, the dashboard opens in the browser automatically; after
+    # that, use the tray icon (a startup toast still says it's running).
+    "has_launched_before": False,
     # Donation nag state -- see webapp.py's /api/donate/* routes. Once
     # donated is True, the weekly popup stops forever; last_donate_prompt_at
     # (unix seconds, 0 = never) just throttles it to once a week otherwise.

--- a/config.py
+++ b/config.py
@@ -90,6 +90,17 @@ DEFAULT_CONFIG = {
     "sample_width": 2,  # bytes (16-bit PCM)
     "http_port": 5757,
     "speakers": {},  # uid -> {"enabled": bool, "volume": int}
+    # Normally the app finds speakers by SSDP multicast and these stay
+    # empty. They only matter when the Sonos speakers are on a different
+    # subnet / VLAN (e.g. an IoT VLAN) than this PC: routers don't forward
+    # SSDP multicast across VLANs, so automatic discovery finds nothing,
+    # but unicast control still works. Put ONE speaker's IP in
+    # sonos_seed_ips (give it a DHCP reservation) -- the app reaches it
+    # directly and learns the whole household from it. sonos_scan_cidrs
+    # is an alternative: a subnet in CIDR form (e.g. "10.0.20.0/24") that
+    # gets a unicast port-1400 sweep when no seed is reachable.
+    "sonos_seed_ips": [],
+    "sonos_scan_cidrs": [],
     # Donation nag state -- see webapp.py's /api/donate/* routes. Once
     # donated is True, the weekly popup stops forever; last_donate_prompt_at
     # (unix seconds, 0 = never) just throttles it to once a week otherwise.

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -166,7 +166,7 @@ def system_snapshot():
     try:
         from sonos_ctl import speaker_mgr
         try:
-            known = sorted(speaker_mgr._known_ips)
+            known = speaker_mgr.known_ips()
             lines.append(f"  (speaker IPs reached this run: {known or '(none)'})")
         except Exception:
             pass

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -181,6 +181,12 @@ def system_snapshot():
 
     lines.append(f"Config: local_delay_ms={config.get('local_delay_ms')} "
                  f"http_port={config.get('http_port')}")
+    try:
+        from config import PASSWORD_PATH
+        # report only whether it's set, never the value
+        lines.append(f"Dashboard password: {'set' if PASSWORD_PATH.exists() else 'not set (dashboard open)'}")
+    except Exception:
+        pass
     return "\n".join(lines)
 
 

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -156,9 +156,20 @@ def system_snapshot():
     except Exception as e:
         lines.append(f"  (couldn't list: {type(e).__name__}: {e})")
 
+    seed_ips = config.get("sonos_seed_ips") or []
+    scan_cidrs = config.get("sonos_scan_cidrs") or []
+    lines.append(f"Manual Sonos seed IPs (cross-VLAN): {seed_ips or '(none)'}")
+    if scan_cidrs:
+        lines.append(f"Manual Sonos scan subnets: {scan_cidrs}")
+
     lines.append("Sonos speakers PC2Sonos has found:")
     try:
         from sonos_ctl import speaker_mgr
+        try:
+            known = sorted(speaker_mgr._known_ips)
+            lines.append(f"  (speaker IPs reached this run: {known or '(none)'})")
+        except Exception:
+            pass
         speakers = speaker_mgr.list()
         if not speakers:
             lines.append("  (none found yet)")

--- a/main.py
+++ b/main.py
@@ -24,6 +24,42 @@ import time
 from pathlib import Path
 
 
+_NOOP_LOCK = object()  # stand-in "we hold the lock" on non-Windows
+
+
+def acquire_single_instance_lock(name="PC2Sonos"):
+    """Take a machine-session-wide named lock so a second copy of the app
+    can bow out instead of fighting the first one for the HTTP port, the
+    capture device, and control of the speakers.
+
+    This actually bites at login: Windows sometimes runs a Startup-folder
+    item twice (Explorer re-processing the folder when it restarts early
+    in the session), and both copies then boot-start the same speaker and
+    run their own watchdogs against it.
+
+    Returns an opaque handle to keep alive for the process lifetime, or
+    None if another instance already holds the lock. Never raises -- if
+    the OS call fails we return the handle and let the app start."""
+    if sys.platform != "win32":
+        return _NOOP_LOCK
+    try:
+        import ctypes
+        ERROR_ALREADY_EXISTS = 183
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        # no "Global\\" prefix -> scoped to this login session, which is
+        # exactly where the double-launch happens; also avoids needing
+        # any special privilege
+        handle = kernel32.CreateMutexW(None, False, f"{name}-single-instance")
+        if not handle:
+            return _NOOP_LOCK
+        if ctypes.get_last_error() == ERROR_ALREADY_EXISTS:
+            kernel32.CloseHandle(handle)
+            return None
+        return handle
+    except Exception:
+        return _NOOP_LOCK
+
+
 def _wait_for_http(port, stop_event, timeout=20):
     """Block until something is accepting TCP connections on
     127.0.0.1:<port> (our Flask server), or `timeout` seconds pass, or we
@@ -108,11 +144,19 @@ def sonos_discovery_loop(stop_event, on_demand=False, ready_event=None):
 
 
 def main():
-    # first thing, no matter what -- so a crash in anything below this
-    # line still gets a full traceback in the log instead of just
-    # silently stopping. This is the difference between "someone else's
-    # PC has a bug we'll never see" and "someone else's PC has a bug we
-    # can actually read about."
+    # Bail out early if another copy is already running -- before we touch
+    # the HTTP port, the capture device, or any speaker. Held for the
+    # process lifetime via this local (main() never returns until exit).
+    _instance_lock = acquire_single_instance_lock()
+    if _instance_lock is None:
+        print("[startup] another PC2Sonos instance is already running -- exiting")
+        return
+
+    # first thing after that -- so a crash in anything below this line
+    # still gets a full traceback in the log instead of just silently
+    # stopping. This is the difference between "someone else's PC has a
+    # bug we'll never see" and "someone else's PC has a bug we can
+    # actually read about."
     install_global_exception_logging()
 
     stop_event = threading.Event()

--- a/main.py
+++ b/main.py
@@ -17,10 +17,25 @@ your Windows default playback device -- see README.md.
 """
 
 import os
+import socket
 import sys
 import threading
 import time
 from pathlib import Path
+
+
+def _wait_for_http(port, stop_event, timeout=20):
+    """Block until something is accepting TCP connections on
+    127.0.0.1:<port> (our Flask server), or `timeout` seconds pass, or we
+    were asked to stop. Returns True if the port came up."""
+    deadline = time.monotonic() + timeout
+    while not stop_event.is_set() and time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            stop_event.wait(0.2)
+    return False
 
 
 def _setup_logging():
@@ -56,16 +71,40 @@ from diagnostics import install_global_exception_logging, system_snapshot  # noq
 import webapp  # noqa: E402
 
 
-def sonos_discovery_loop(stop_event):
+def _rediscover_guarded():
+    try:
+        speaker_mgr.rediscover()
+    except Exception as e:
+        # never let one bad discovery pass silently kill the loop --
+        # without this, a single hiccup means Sonos speakers are never
+        # found again for the rest of the run
+        print(f"[sonos] discovery loop error: {e}")
+
+
+def sonos_discovery_loop(stop_event, on_demand=False, ready_event=None):
+    """Keep the speaker list current.
+
+    Default ("auto"): a full re-scan every 15s.
+
+    "on_demand" (set once the configured default speaker came up at
+    launch): hold the one safety-net scan until audio to the default
+    speaker is underway (ready_event, set after stream_keeper's first
+    pass) so the scan stays out of the startup crunch -- it only
+    populates the dashboard with the other speakers, nothing time-
+    critical. Then idle, re-scanning only when the Rescan button asks.
+    The 20s is a fallback in case that first pass never completes."""
+    if on_demand:
+        (ready_event or stop_event).wait(20)
+        while not stop_event.is_set():
+            _rediscover_guarded()
+            while not stop_event.is_set() and not speaker_mgr.rescan_requested.wait(30):
+                pass
+            speaker_mgr.rescan_requested.clear()
+        return
+
     while not stop_event.is_set():
-        try:
-            speaker_mgr.rediscover()
-        except Exception as e:
-            # never let one bad discovery pass silently kill the loop --
-            # without this, a single hiccup means Sonos speakers are
-            # never found again for the rest of the run
-            print(f"[sonos] discovery loop error: {e}")
-        time.sleep(15)
+        _rediscover_guarded()
+        stop_event.wait(15)
 
 
 def main():
@@ -77,6 +116,10 @@ def main():
     install_global_exception_logging()
 
     stop_event = threading.Event()
+    # set after stream_keeper's first watchdog pass -- the on_demand
+    # discovery loop waits on this so its (non-urgent) full scan doesn't
+    # compete with getting audio to the default speaker at launch
+    first_tick_done = threading.Event()
 
     if sys.platform == "win32":
         # self-configure: if the virtual cable exists but isn't the
@@ -103,7 +146,22 @@ def main():
 
     start_audio_engine(stop_event)
 
-    disc_thread = threading.Thread(target=sonos_discovery_loop, args=(stop_event,), daemon=True)
+    # Fast path: if a default speaker is configured, reach it directly now
+    # (one unicast call) so the watchdog can start streaming to it in a
+    # second or two, instead of waiting out a full discovery pass.
+    primed_uid = None
+    try:
+        primed_uid = speaker_mgr.prime_default_speaker()
+    except Exception as e:
+        print(f"[sonos] default-speaker prime failed: {e}")
+
+    on_demand = (config.get("discovery_mode") == "on_demand" and primed_uid is not None)
+    if on_demand:
+        print("[sonos] discovery_mode=on_demand: background re-scanning off "
+              "(one safety-net pass, then only on request)")
+    disc_thread = threading.Thread(
+        target=sonos_discovery_loop,
+        args=(stop_event, on_demand, first_tick_done), daemon=True)
     disc_thread.start()
 
     def log_startup_snapshot():
@@ -124,18 +182,22 @@ def main():
 
     def stream_keeper():
         # The watchdog owns both jobs: the boot-time start (it force-
-        # starts each enabled speaker the first time discovery hands it
-        # to us -- no race against discovery timing) and staying alive
-        # (if Sonos ever drops the stream -- sleep, wifi blip, source
-        # switch and back -- it restarts it automatically instead of
-        # waiting for a human to re-toggle).
-        time.sleep(5)
+        # starts each enabled speaker the first time discovery -- or the
+        # default-speaker prime -- hands it to us) and staying alive (if
+        # Sonos ever drops the stream -- sleep, wifi blip, source switch
+        # and back -- it restarts it automatically, no re-toggle needed).
+        #
+        # First tick waits only until the HTTP server is actually
+        # accepting connections (a Sonos speaker told to play before then
+        # would fail to fetch the stream), not a fixed guess.
+        _wait_for_http(config["http_port"], stop_event, timeout=20)
         while not stop_event.is_set():
             try:
                 speaker_mgr.watchdog_tick(f"http://{get_lan_ip()}:{config['http_port']}")
             except Exception as e:
                 print(f"[sonos] watchdog error: {e}")
-            time.sleep(8)
+            first_tick_done.set()  # release the on_demand discovery loop
+            stop_event.wait(8)
 
     threading.Thread(target=stream_keeper, daemon=True).start()
 
@@ -145,23 +207,41 @@ def main():
     except Exception as e:
         print(f"[tray] system tray icon not available: {e}")
 
-    def open_dashboard_once_ready():
+    def announce_startup():
         # webapp.run_web() below blocks until the process exits, so this
-        # has to happen on its own thread -- and needs a moment first so
-        # the Flask server actually has a socket open to browse to.
-        # Previously the dashboard only opened automatically on the very
-        # first run (from setup_installer.py) or if someone found the
-        # tray icon's "Open Dashboard" item -- every other launch (every
-        # normal Windows login, via the Startup shortcut) started the app
-        # with no visible sign it had, unless you went looking for it.
-        time.sleep(1.5)
-        try:
-            import webbrowser
-            webbrowser.open(f"http://127.0.0.1:{config['http_port']}")
-        except Exception as e:
-            print(f"[web] couldn't auto-open the dashboard: {e}")
+        # runs on its own thread and waits for the HTTP server first.
+        #
+        # First launch on this machine: open the dashboard so setup (sync
+        # delay, which speakers) actually gets done. Every launch after
+        # that -- i.e. every normal Windows login via the Startup shortcut
+        # -- don't steal focus with a browser tab; just pop a tray balloon
+        # so there's still a visible sign it started. The dashboard is one
+        # click away on the tray icon whenever it's wanted.
+        first_run = not config.get("has_launched_before")
+        if not _wait_for_http(config["http_port"], stop_event, timeout=30):
+            return
+        if first_run:
+            try:
+                import webbrowser
+                webbrowser.open(f"http://127.0.0.1:{config['http_port']}")
+            except Exception as e:
+                print(f"[web] couldn't auto-open the dashboard: {e}")
+        else:
+            try:
+                import tray_icon
+                tray_icon.notify(
+                    f"Running. Dashboard: http://127.0.0.1:{config['http_port']}")
+            except Exception:
+                pass
+        if first_run:
+            config["has_launched_before"] = True
+            try:
+                from config import save_config
+                save_config(config)
+            except Exception as e:
+                print(f"[config] couldn't record first launch: {e}")
 
-    threading.Thread(target=open_dashboard_once_ready, daemon=True).start()
+    threading.Thread(target=announce_startup, daemon=True).start()
 
     print(f"[web] dashboard: http://127.0.0.1:{config['http_port']}")
     webapp.run_web()

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -445,9 +445,9 @@ class SpeakerManager:
 
     def request_rescan(self):
         """One immediate discovery pass, plus a nudge for the on_demand
-        loop (which is otherwise idle)."""
+        loop (which is otherwise idle). Returns rediscover()'s status."""
         self.rescan_requested.set()
-        self.rediscover()
+        return self.rediscover()
 
     def set_volume(self, uid, volume):
         zone = self.speakers.get(uid)

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -196,12 +196,22 @@ class SpeakerManager:
         ip = str(config.get("default_speaker_ip") or "").strip()
         if not ip:
             return None
-        try:
-            zone = SoCo(ip)
-            uid = zone.uid
-        except Exception as e:
-            print(f"[sonos] default speaker {ip} not reachable at launch: {e}")
-            return None
+        # A speaker waking from standby can take longer than the 4s
+        # REQUEST_TIMEOUT to answer its first request. Give it a few
+        # tries before falling back to normal discovery, otherwise a
+        # cold-boot default speaker silently misses the fast-start path.
+        zone = uid = None
+        for attempt in range(3):
+            try:
+                zone = SoCo(ip)
+                uid = zone.uid
+                break
+            except Exception as e:
+                if attempt == 2:
+                    print(f"[sonos] default speaker {ip} not reachable at "
+                          f"launch after {attempt + 1} tries: {e}")
+                    return None
+                time.sleep(2)
 
         expected = str(config.get("default_speaker_uid") or "").strip()
         if expected and expected != uid:

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -4,9 +4,18 @@ import threading
 import time
 from xml.sax.saxutils import escape
 
-from soco.discovery import discover
+import soco.config as soco_config
+from soco import SoCo
+from soco.discovery import discover, scan_network
 
 from config import config, save_config
+
+# SoCo's default is 20s. A speaker that's asleep or briefly off-network
+# then stalls every code path that touches it for 20s at a time -- and
+# with cross-subnet (unicast) discovery there's no multicast "who's
+# alive" to prune the dead ones, so this happens routinely. 4s is plenty
+# for a speaker that's actually there on the LAN.
+soco_config.REQUEST_TIMEOUT = 4.0
 
 
 def _track_metadata(title):
@@ -132,6 +141,11 @@ def _effective_zone(zone):
 class SpeakerManager:
     def __init__(self):
         self.speakers = {}   # uid -> soco.SoCo
+        self.names = {}      # uid -> str, cached at discovery so list()
+                             # never has to make a (possibly hanging)
+                             # network call just to render the dashboard
+        self.groups = {}     # uid -> [other member names], same reason:
+                             # refreshed from the background threads only
         self.streams = {}    # uid -> bool
         self._lock = threading.Lock()
         # uid -> monotonic time of our last automatic restart, so the
@@ -143,10 +157,72 @@ class SpeakerManager:
         self._boot_started = set()
         # speakers we've already logged a query failure for (log noise cap)
         self._warned = set()
+        # IPs of speakers we've successfully reached this run, seeded from
+        # config but grown as we discover more. Used as extra entry points
+        # for the unicast (cross-VLAN) discovery path so that if the one
+        # configured seed is down, any other speaker we've seen still gets
+        # us back to the whole household.
+        self._known_ips = set()
+
+    def _discover_zones(self):
+        """Return the set of Sonos zones to track.
+
+        Normal path: SSDP multicast (`discover`). That's all that runs on
+        a flat network and it's fast.
+
+        Cross-subnet path: when the speakers are on a different VLAN (an
+        IoT VLAN is the common case), the router won't forward SSDP
+        multicast, so `discover` comes back empty even though unicast
+        control works fine. Fall back to talking to a known speaker IP
+        directly -- reaching ANY one speaker yields the entire household
+        via its ZoneGroupTopology -- and, failing that, to a unicast
+        sweep of an operator-supplied subnet."""
+        try:
+            found = discover(timeout=5) or set()
+        except Exception as e:
+            print(f"[sonos] SSDP discovery error: {e}")
+            found = set()
+        if found:
+            return found
+
+        seeds = list(config.get("sonos_seed_ips") or []) + sorted(self._known_ips)
+        zones = set()
+        tried = set()
+        for ip in seeds:
+            ip = str(ip).strip()
+            if not ip or ip in tried:
+                continue
+            tried.add(ip)
+            try:
+                device = SoCo(ip)
+                # Warm the household's shared ZoneGroupState cache from
+                # THIS speaker, which we know we just reached -- otherwise
+                # the first .player_name access later might land on a
+                # speaker that's currently asleep and stall/return blank.
+                # The reachable seed's topology already carries every
+                # zone's name.
+                _ = device.player_name
+                zones |= (device.visible_zones or {device})
+            except Exception as e:
+                print(f"[sonos] seed speaker {ip} unreachable: {e}")
+        if zones:
+            return zones
+
+        for cidr in config.get("sonos_scan_cidrs") or []:
+            cidr = str(cidr).strip()
+            if not cidr:
+                continue
+            try:
+                print(f"[sonos] SSDP found nothing; unicast-scanning {cidr}")
+                zones |= (scan_network(networks_to_scan=[cidr],
+                                       multi_household=True) or set())
+            except Exception as e:
+                print(f"[sonos] subnet scan of {cidr} failed: {e}")
+        return zones
 
     def rediscover(self):
         try:
-            found = discover(timeout=5) or set()
+            found = self._discover_zones()
         except Exception as e:
             print(f"[sonos] discovery error: {e}")
             return
@@ -159,6 +235,12 @@ class SpeakerManager:
             with self._lock:
                 for zone in found:
                     uid = zone.uid
+                    try:
+                        if zone.ip_address:
+                            self._known_ips.add(zone.ip_address)
+                    except Exception:
+                        pass
+                    self._refresh_zone_meta(uid, zone)
                     if uid not in self.speakers:
                         self.speakers[uid] = zone
                         if uid not in config["speakers"]:
@@ -170,34 +252,62 @@ class SpeakerManager:
                             # slider). 50% is a sane, unsurprising starting
                             # point for every newly-discovered speaker.
                             config["speakers"][uid] = {"enabled": True, "volume": 50}
-                        print(f"[sonos] found: {zone.player_name}")
+                        print(f"[sonos] found: {self.names.get(uid, uid)}")
             save_config(config)
         except Exception as e:
             print(f"[sonos] discovery bookkeeping error: {e}")
+
+    def _refresh_zone_meta(self, uid, zone):
+        """Pull this zone's display name and current group membership into
+        our own caches. Called only from the background discovery/watchdog
+        threads, never from list() -- those threads already tolerate a
+        slow or failed call, the dashboard poll does not."""
+        try:
+            name = zone.player_name
+            if name:
+                self.names[uid] = name
+        except Exception:
+            return
+        try:
+            grp = zone.group
+            others = []
+            for m in (grp.members if grp is not None else []):
+                # skip the zone itself and any bonded satellites/subs --
+                # those aren't separately-controllable "speakers", they'd
+                # just show up as a confusing "grouped with Sub, Sub"
+                if m.uid == uid:
+                    continue
+                try:
+                    if not m.is_visible:
+                        continue
+                except Exception:
+                    continue
+                if m.player_name:
+                    others.append(m.player_name)
+            self.groups[uid] = sorted(others)
+        except Exception:
+            pass
 
     def list(self):
         with self._lock:
             out = []
             for uid, zone in self.speakers.items():
                 cfg = config["speakers"].get(uid, {"enabled": True, "volume": 50})
-                # surfaced so the dashboard can show "grouped with X, Y" --
-                # toggling any one of them actually affects the whole group
-                # (see _effective_zone), so the UI shouldn't imply otherwise
-                group_members = []
-                try:
-                    grp = zone.group
-                    if grp is not None and len(grp.members) > 1:
-                        group_members = sorted(
-                            m.player_name for m in grp.members if m.player_name != zone.player_name)
-                except Exception:
-                    pass
+                # Reads cached state ONLY -- nothing here makes a network
+                # call. The dashboard polls this every few seconds, and a
+                # single asleep/off-network speaker used to make the whole
+                # call hang, then 500, on SoCo's request timeout.
                 out.append({
                     "uid": uid,
-                    "name": zone.player_name,
+                    "name": self.names.get(uid, uid),
                     "enabled": cfg.get("enabled", True),
                     "volume": cfg.get("volume", 50),
                     "streaming": self.streams.get(uid, False),
-                    "grouped_with": group_members,
+                    # surfaced so the dashboard can show "grouped with X, Y"
+                    # -- toggling any one of them affects the whole group
+                    # (see _effective_zone), so the UI shouldn't imply
+                    # otherwise
+                    "grouped_with": self.groups.get(uid, []),
                 })
             return sorted(out, key=lambda s: s["name"])
 

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -163,6 +163,54 @@ class SpeakerManager:
         # configured seed is down, any other speaker we've seen still gets
         # us back to the whole household.
         self._known_ips = set()
+        # set by the dashboard's "Rescan" button (and used to break the
+        # discovery loop out of its wait in on_demand mode)
+        self.rescan_requested = threading.Event()
+
+    def _default_enabled_for(self, uid):
+        """Whether a newly-seen speaker should start out enabled. The
+        configured default speaker always is; everything else follows
+        new_speakers_default_enabled (true on a fresh install)."""
+        if uid and uid == config.get("default_speaker_uid"):
+            return True
+        return bool(config.get("new_speakers_default_enabled", True))
+
+    def prime_default_speaker(self):
+        """Reach config['default_speaker_ip'] directly and register it,
+        so the watchdog can boot-start it without waiting for a discovery
+        pass. Returns the uid on success, None otherwise (blank config,
+        speaker unreachable, or the IP now answers as a different device).
+
+        Safe to call repeatedly -- it's a no-op once the speaker is
+        already known."""
+        ip = str(config.get("default_speaker_ip") or "").strip()
+        if not ip:
+            return None
+        try:
+            zone = SoCo(ip)
+            uid = zone.uid
+        except Exception as e:
+            print(f"[sonos] default speaker {ip} not reachable at launch: {e}")
+            return None
+
+        expected = str(config.get("default_speaker_uid") or "").strip()
+        if expected and expected != uid:
+            print(f"[sonos] {ip} is now {uid}, not the configured default "
+                  f"speaker {expected} -- ignoring it, letting discovery take over")
+            return None
+
+        with self._lock:
+            if not expected:
+                config["default_speaker_uid"] = uid
+                save_config(config)
+            self._known_ips.add(ip)
+            self._refresh_zone_meta(uid, zone)
+            self.speakers.setdefault(uid, zone)
+            config["speakers"].setdefault(
+                uid, {"enabled": True, "volume": 50})["enabled"] = True
+            save_config(config)
+        print(f"[sonos] default speaker ready at launch: {self.names.get(uid, uid)}")
+        return uid
 
     def _discover_zones(self):
         """Return the set of Sonos zones to track.
@@ -251,7 +299,10 @@ class SpeakerManager:
                             # the zone until someone actually touches the
                             # slider). 50% is a sane, unsurprising starting
                             # point for every newly-discovered speaker.
-                            config["speakers"][uid] = {"enabled": True, "volume": 50}
+                            config["speakers"][uid] = {
+                                "enabled": self._default_enabled_for(uid),
+                                "volume": 50,
+                            }
                         print(f"[sonos] found: {self.names.get(uid, uid)}")
             save_config(config)
         except Exception as e:
@@ -303,6 +354,8 @@ class SpeakerManager:
                     "enabled": cfg.get("enabled", True),
                     "volume": cfg.get("volume", 50),
                     "streaming": self.streams.get(uid, False),
+                    "ip": getattr(zone, "ip_address", "") or "",
+                    "is_default": uid == config.get("default_speaker_uid"),
                     # surfaced so the dashboard can show "grouped with X, Y"
                     # -- toggling any one of them affects the whole group
                     # (see _effective_zone), so the UI shouldn't imply
@@ -321,6 +374,32 @@ class SpeakerManager:
             self.start_stream(uid, zone, base_url)
         else:
             self.stop_stream(uid, zone)
+
+    def set_default_speaker(self, uid):
+        """Pin (or, with a falsy uid, clear) the speaker PC2Sonos talks
+        to directly at launch. Returns True on success, False if the uid
+        isn't a speaker we currently know an IP for."""
+        with self._lock:
+            if not uid:
+                config["default_speaker_ip"] = ""
+                config["default_speaker_uid"] = ""
+                save_config(config)
+                return True
+            ip = getattr(self.speakers.get(uid), "ip_address", "") or ""
+            if not ip:
+                return False
+            config["default_speaker_ip"] = ip
+            config["default_speaker_uid"] = uid
+            config["speakers"].setdefault(
+                uid, {"enabled": True, "volume": 50})["enabled"] = True
+            save_config(config)
+        return True
+
+    def request_rescan(self):
+        """One immediate discovery pass, plus a nudge for the on_demand
+        loop (which is otherwise idle)."""
+        self.rescan_requested.set()
+        self.rediscover()
 
     def set_volume(self, uid, volume):
         zone = self.speakers.get(uid)

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -209,16 +209,19 @@ class SpeakerManager:
                   f"speaker {expected} -- ignoring it, letting discovery take over")
             return None
 
+        name, groups = self._zone_meta(zone)  # network I/O -- keep it off the lock
         with self._lock:
             if not expected:
                 config["default_speaker_uid"] = uid
-                save_config(config)
             self._known_ips.add(ip)
-            self._refresh_zone_meta(uid, zone)
+            if name:
+                self.names[uid] = name
+            if groups is not None:
+                self.groups[uid] = groups
             self.speakers.setdefault(uid, zone)
             config["speakers"].setdefault(
                 uid, {"enabled": True, "volume": 50})["enabled"] = True
-            save_config(config)
+        save_config(config)
         print(f"[sonos] default speaker ready at launch: {self.names.get(uid, uid)}")
         return uid
 
@@ -282,11 +285,33 @@ class SpeakerManager:
         return zones
 
     def rediscover(self):
+        """Run a discovery pass and merge the results. Returns True if it
+        completed, False if something went wrong along the way (the
+        dashboard's rescan routes surface this)."""
         try:
             found = self._discover_zones()
         except Exception as e:
             print(f"[sonos] discovery error: {e}")
-            return
+            return False
+
+        # Resolve each zone's name + group membership -- which is network
+        # I/O, up to a REQUEST_TIMEOUT per unreachable zone -- BEFORE
+        # taking self._lock. list() needs that same lock for every
+        # /api/speakers poll (every 4s), so doing this under it would let
+        # one asleep speaker stall the whole dashboard.
+        resolved = []  # (uid, zone, ip, name, groups)
+        for zone in found:
+            try:
+                uid = zone.uid
+            except Exception:
+                continue
+            try:
+                ip = zone.ip_address or ""
+            except Exception:
+                ip = ""
+            name, groups = self._zone_meta(zone)
+            resolved.append((uid, zone, ip, name, groups))
+
         # everything below used to run unguarded -- a single flaky zone
         # (a bad .volume read, a save_config hiccup) would raise straight
         # out of rediscover() and kill the discovery thread for the rest
@@ -294,14 +319,13 @@ class SpeakerManager:
         # obvious reason why. Guard it so that can't happen.
         try:
             with self._lock:
-                for zone in found:
-                    uid = zone.uid
-                    try:
-                        if zone.ip_address:
-                            self._known_ips.add(zone.ip_address)
-                    except Exception:
-                        pass
-                    self._refresh_zone_meta(uid, zone)
+                for uid, zone, ip, name, groups in resolved:
+                    if ip:
+                        self._known_ips.add(ip)
+                    if name:
+                        self.names[uid] = name
+                    if groups is not None:
+                        self.groups[uid] = groups
                     if uid not in self.speakers:
                         self.speakers[uid] = zone
                         if uid not in config["speakers"]:
@@ -320,18 +344,19 @@ class SpeakerManager:
             save_config(config)
         except Exception as e:
             print(f"[sonos] discovery bookkeeping error: {e}")
+            return False
+        return True
 
-    def _refresh_zone_meta(self, uid, zone):
-        """Pull this zone's display name and current group membership into
-        our own caches. Called only from the background discovery/watchdog
-        threads, never from list() -- those threads already tolerate a
-        slow or failed call, the dashboard poll does not."""
+    def _zone_meta(self, zone):
+        """(display name, sorted list of visible group-member names) for a
+        zone. Makes network calls (player_name / group topology), so this
+        must run OUTSIDE self._lock and the caller merges the result in
+        afterwards. Returns (None, None) if the zone can't be reached;
+        (name, None) if the name resolved but the group didn't."""
         try:
-            name = zone.player_name
-            if name:
-                self.names[uid] = name
+            name = zone.player_name or None
         except Exception:
-            return
+            return None, None
         try:
             grp = zone.group
             others = []
@@ -339,7 +364,7 @@ class SpeakerManager:
                 # skip the zone itself and any bonded satellites/subs --
                 # those aren't separately-controllable "speakers", they'd
                 # just show up as a confusing "grouped with Sub, Sub"
-                if m.uid == uid:
+                if m.uid == zone.uid:
                     continue
                 try:
                     if not m.is_visible:
@@ -348,9 +373,9 @@ class SpeakerManager:
                     continue
                 if m.player_name:
                     others.append(m.player_name)
-            self.groups[uid] = sorted(others)
+            return name, sorted(others)
         except Exception:
-            pass
+            return name, None
 
     def list(self):
         with self._lock:

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -167,6 +167,16 @@ class SpeakerManager:
         # discovery loop out of its wait in on_demand mode)
         self.rescan_requested = threading.Event()
 
+    def known_ips(self):
+        """A locked snapshot (sorted list) of the speaker IPs reached so
+        far this run. `_known_ips` is mutated from the discovery and
+        prime paths under `self._lock`; callers here run on other threads
+        (get_lan_ip on the watchdog thread, the diagnostics snapshot, the
+        next discovery pass), and iterating the set unlocked while it's
+        being added to raises 'Set changed size during iteration'."""
+        with self._lock:
+            return sorted(self._known_ips)
+
     def _default_enabled_for(self, uid):
         """Whether a newly-seen speaker should start out enabled. The
         configured default speaker always is; everything else follows
@@ -233,7 +243,7 @@ class SpeakerManager:
         if found:
             return found
 
-        seeds = list(config.get("sonos_seed_ips") or []) + sorted(self._known_ips)
+        seeds = list(config.get("sonos_seed_ips") or []) + self.known_ips()
         zones = set()
         tried = set()
         for ip in seeds:

--- a/sonos_ctl.py
+++ b/sonos_ctl.py
@@ -223,32 +223,41 @@ class SpeakerManager:
         return uid
 
     def _discover_zones(self):
-        """Return the set of Sonos zones to track.
+        """The set of Sonos zones to track, from every source that applies
+        -- results are UNIONed, not taken from the first that returns
+        something (a SoCo set dedupes by uid).
 
-        Normal path: SSDP multicast (`discover`). That's all that runs on
-        a flat network and it's fast.
-
-        Cross-subnet path: when the speakers are on a different VLAN (an
-        IoT VLAN is the common case), the router won't forward SSDP
-        multicast, so `discover` comes back empty even though unicast
-        control works fine. Fall back to talking to a known speaker IP
-        directly -- reaching ANY one speaker yields the entire household
-        via its ZoneGroupTopology -- and, failing that, to a unicast
-        sweep of an operator-supplied subnet."""
+        - SSDP multicast (`discover`): on a flat network this alone is
+          complete -- and on a hit `soco.discovery.discover` already
+          returns the responder's full `visible_zones`, so a single
+          household that meshes across VLANs over SonosNet comes back
+          whole here too.
+        - Configured `sonos_seed_ips`: always walked when set. A mixed
+          setup -- some speakers on the LAN, a separate Sonos system on
+          an IoT VLAN reachable only by unicast -- would otherwise never
+          find the VLAN speakers once SSDP returns the LAN ones. Reaching
+          any one speaker yields its whole household via ZoneGroupTopology.
+        - `sonos_scan_cidrs`: a unicast subnet sweep. Last resort (it's
+          the expensive one) -- only when nothing else turned anything up.
+        - Previously-seen IPs (`known_ips()`): a recovery path, used only
+          when SSDP and any configured seeds all came back empty."""
+        zones = set()
         try:
-            found = discover(timeout=5) or set()
+            zones |= discover(timeout=5) or set()
         except Exception as e:
             print(f"[sonos] SSDP discovery error: {e}")
-            found = set()
-        if found:
-            return found
 
-        seeds = list(config.get("sonos_seed_ips") or []) + self.known_ips()
-        zones = set()
+        seed_ips = [str(s).strip() for s in (config.get("sonos_seed_ips") or [])
+                    if str(s).strip()]
+        scan_cidrs = [str(c).strip() for c in (config.get("sonos_scan_cidrs") or [])
+                      if str(c).strip()]
+
+        seeds = list(seed_ips)
+        if not zones and not seeds:
+            seeds = self.known_ips()
         tried = set()
         for ip in seeds:
-            ip = str(ip).strip()
-            if not ip or ip in tried:
+            if ip in tried:
                 continue
             tried.add(ip)
             try:
@@ -257,25 +266,19 @@ class SpeakerManager:
                 # THIS speaker, which we know we just reached -- otherwise
                 # the first .player_name access later might land on a
                 # speaker that's currently asleep and stall/return blank.
-                # The reachable seed's topology already carries every
-                # zone's name.
                 _ = device.player_name
                 zones |= (device.visible_zones or {device})
             except Exception as e:
                 print(f"[sonos] seed speaker {ip} unreachable: {e}")
-        if zones:
-            return zones
 
-        for cidr in config.get("sonos_scan_cidrs") or []:
-            cidr = str(cidr).strip()
-            if not cidr:
-                continue
-            try:
-                print(f"[sonos] SSDP found nothing; unicast-scanning {cidr}")
-                zones |= (scan_network(networks_to_scan=[cidr],
-                                       multi_household=True) or set())
-            except Exception as e:
-                print(f"[sonos] subnet scan of {cidr} failed: {e}")
+        if scan_cidrs and not zones:
+            for cidr in scan_cidrs:
+                try:
+                    print(f"[sonos] nothing found yet; unicast-scanning {cidr}")
+                    zones |= (scan_network(networks_to_scan=[cidr],
+                                           multi_household=True) or set())
+                except Exception as e:
+                    print(f"[sonos] subnet scan of {cidr} failed: {e}")
         return zones
 
     def rediscover(self):

--- a/test_logic.py
+++ b/test_logic.py
@@ -365,6 +365,20 @@ finally:
     sonos_ctl.speaker_mgr.rescan_requested.clear()
 print("  OK")
 
+print("[test] single-instance lock: second acquire is refused...")
+# unique name so this doesn't collide with a real running PC2Sonos.exe
+_lock_name = f"PC2Sonos-test-{os.getpid()}"
+_h1 = _main.acquire_single_instance_lock(_lock_name)
+assert _h1 is not None, "first acquire should succeed"
+_h2 = _main.acquire_single_instance_lock(_lock_name)
+if sys.platform == "win32":
+    assert _h2 is None, "second acquire (same name) must be refused"
+    import ctypes as _ct
+    _ct.WinDLL("kernel32").CloseHandle(_h1)  # release so nothing wedges
+else:
+    assert _h2 is not None, "non-Windows: lock is a no-op, always granted"
+print("  OK")
+
 print("[test] diagnostics module...")
 import diagnostics  # noqa: E402
 

--- a/test_logic.py
+++ b/test_logic.py
@@ -298,7 +298,9 @@ try:
         def group(self):
             return None
     _orig_soco = sonos_ctl.SoCo
+    _orig_sleep = sonos_ctl.time.sleep
     sonos_ctl.SoCo = FakeSoCo
+    sonos_ctl.time.sleep = lambda _s: None   # don't wait out the prime retry
     try:
         _cfg["default_speaker_ip"] = ""
         _cfg["default_speaker_uid"] = ""
@@ -323,6 +325,7 @@ try:
         assert m2c.prime_default_speaker() is None
     finally:
         sonos_ctl.SoCo = _orig_soco
+        sonos_ctl.time.sleep = _orig_sleep
 
     # set_default_speaker: pin by uid (needs a known IP), and clear
     m3 = sonos_ctl.SpeakerManager()

--- a/test_logic.py
+++ b/test_logic.py
@@ -226,6 +226,7 @@ class FakeZone:
 
 mgr = sonos_ctl.SpeakerManager()
 base = "http://192.168.1.5:5757"
+_wd_saved_speakers = dict(webapp.config["speakers"])  # restored at end of this block
 
 uid_a = "RINCON_AAAA0001"
 za = FakeZone(uid_a, f"{base}/stream/{uid_a}.wav", "STOPPED")  # our stream, dropped
@@ -265,6 +266,103 @@ webapp.config["speakers"][uid_c] = {"enabled": True, "volume": 50}
 mgr.watchdog_tick(base)
 assert zc.play_count == 1, "idle speaker should be claimed at boot"
 assert zb.play_count == 0, "actively-playing other source must stay untouched"
+webapp.config["speakers"] = _wd_saved_speakers  # don't leak fake speakers to config.json
+print("  OK")
+
+print("[test] startup: default speaker + new-speaker-enabled default...")
+_cfg = sonos_ctl.config
+_saved = {k: _cfg.get(k) for k in
+          ("default_speaker_ip", "default_speaker_uid", "new_speakers_default_enabled")}
+_saved_speakers = dict(_cfg["speakers"])  # these tests call save_config()
+try:
+    m2 = sonos_ctl.SpeakerManager()
+
+    # _default_enabled_for: follows the config flag, but the default
+    # speaker is always enabled
+    _cfg["new_speakers_default_enabled"] = False
+    _cfg["default_speaker_uid"] = "RINCON_DEFAULT"
+    assert m2._default_enabled_for("RINCON_OTHER") is False
+    assert m2._default_enabled_for("RINCON_DEFAULT") is True
+    _cfg["new_speakers_default_enabled"] = True
+    assert m2._default_enabled_for("RINCON_OTHER") is True
+
+    # prime_default_speaker: reachable IP -> registered + uid recorded
+    class FakeSoCo:
+        def __init__(self, ip):
+            if ip == "10.0.0.9":
+                raise OSError("unreachable")
+            self.ip_address = ip
+            self.uid = "RINCON_PRIMED" if ip == "10.0.0.5" else "RINCON_SOMEONEELSE"
+            self.player_name = "Primed"
+        @property
+        def group(self):
+            return None
+    _orig_soco = sonos_ctl.SoCo
+    sonos_ctl.SoCo = FakeSoCo
+    try:
+        _cfg["default_speaker_ip"] = ""
+        _cfg["default_speaker_uid"] = ""
+        assert m2.prime_default_speaker() is None, "blank IP -> nothing"
+
+        _cfg["default_speaker_ip"] = "10.0.0.5"
+        _cfg["default_speaker_uid"] = ""
+        assert m2.prime_default_speaker() == "RINCON_PRIMED"
+        assert _cfg["default_speaker_uid"] == "RINCON_PRIMED", "uid auto-recorded"
+        assert "RINCON_PRIMED" in m2.speakers
+        assert _cfg["speakers"]["RINCON_PRIMED"]["enabled"] is True
+
+        # IP now answers as a different device -> ignored
+        m2b = sonos_ctl.SpeakerManager()
+        _cfg["default_speaker_ip"] = "10.0.0.7"  # -> RINCON_SOMEONEELSE
+        assert m2b.prime_default_speaker() is None, "uid mismatch -> ignore the IP"
+
+        # unreachable IP -> None, no crash
+        m2c = sonos_ctl.SpeakerManager()
+        _cfg["default_speaker_uid"] = ""
+        _cfg["default_speaker_ip"] = "10.0.0.9"
+        assert m2c.prime_default_speaker() is None
+    finally:
+        sonos_ctl.SoCo = _orig_soco
+
+    # set_default_speaker: pin by uid (needs a known IP), and clear
+    m3 = sonos_ctl.SpeakerManager()
+    m3.speakers["RINCON_X"] = FakeZone("RINCON_X", "", "STOPPED")
+    m3.speakers["RINCON_X"].ip_address = "10.0.0.42"
+    assert m3.set_default_speaker("RINCON_X") is True
+    assert _cfg["default_speaker_ip"] == "10.0.0.42"
+    assert _cfg["default_speaker_uid"] == "RINCON_X"
+    assert m3.set_default_speaker("RINCON_UNKNOWN") is False, "no IP -> refuse"
+    assert m3.set_default_speaker(None) is True
+    assert _cfg["default_speaker_ip"] == "" and _cfg["default_speaker_uid"] == ""
+    print("  OK")
+finally:
+    _cfg.update(_saved)
+    _cfg["speakers"] = _saved_speakers
+    sonos_ctl.save_config(_cfg)
+
+print("[test] on_demand discovery loop: one pass, then idle until asked...")
+import main as _main  # noqa: E402
+_calls = []
+_orig_rd = sonos_ctl.speaker_mgr.rediscover
+sonos_ctl.speaker_mgr.rediscover = lambda: _calls.append(1)
+try:
+    _stop = threading.Event()
+    # shrink the 20s safety-net wait so the test is quick
+    _t = threading.Thread(target=_main.sonos_discovery_loop, args=(_stop, True), daemon=True)
+    # monkeypatch stop_event.wait so the initial 20s becomes instant
+    _real_wait = _stop.wait
+    _stop.wait = lambda t=None: _real_wait(0.05 if t == 20 else (t or 0))
+    _t.start()
+    time.sleep(0.6)
+    assert len(_calls) == 1, f"on_demand should scan exactly once up front, got {len(_calls)}"
+    sonos_ctl.speaker_mgr.rescan_requested.set()  # simulate the Rescan button
+    time.sleep(0.4)
+    assert len(_calls) == 2, "a rescan request should trigger exactly one more scan"
+    _stop.set()
+    sonos_ctl.speaker_mgr.rescan_requested.set()
+finally:
+    sonos_ctl.speaker_mgr.rediscover = _orig_rd
+    sonos_ctl.speaker_mgr.rescan_requested.clear()
 print("  OK")
 
 print("[test] diagnostics module...")

--- a/test_logic.py
+++ b/test_logic.py
@@ -61,8 +61,23 @@ fake_pyaudio.PyAudio = FakePyAudio
 sys.modules["pyaudiowpatch"] = fake_pyaudio
 
 # ---- now safe to import our modules ----
-from config import DEFAULT_CONFIG, load_config, save_config, config  # noqa: E402
+from config import DEFAULT_CONFIG, CONFIG_PATH, load_config, save_config, config  # noqa: E402
 import audio_engine  # noqa: E402
+
+# This harness writes to the real config.json (the round-trip test below,
+# and every POST route that calls save_config). On a dev box that's the
+# live PC2Sonos config -- snapshot it now and put it back on exit no
+# matter how the run ends.
+import atexit  # noqa: E402
+_ORIG_CONFIG_BYTES = CONFIG_PATH.read_bytes() if CONFIG_PATH.exists() else None
+
+
+@atexit.register
+def _restore_real_config():
+    if _ORIG_CONFIG_BYTES is None:
+        CONFIG_PATH.unlink(missing_ok=True)
+    else:
+        CONFIG_PATH.write_bytes(_ORIG_CONFIG_BYTES)
 
 print("[test] config round-trip...")
 cfg = dict(DEFAULT_CONFIG)

--- a/test_logic.py
+++ b/test_logic.py
@@ -163,6 +163,35 @@ wav = webapp.wav_header(44100, 2, 2)
 assert wav[:4] == b"RIFF" and wav[8:12] == b"WAVE" and b"fmt " in wav and b"data" in wav
 print("  wav_header() OK")
 
+# dashboard password: open by default, enforced once PASSWORD_PATH exists,
+# stream endpoint always open (Sonos can't do HTTP auth)
+def _test_dashboard_password():
+    import base64
+    from config import PASSWORD_PATH
+    if PASSWORD_PATH.exists():
+        print(f"  dashboard password test SKIPPED ({PASSWORD_PATH} exists -- won't touch a real one)")
+        return
+    assert webapp._dashboard_password() is None
+    assert client.get("/").status_code == 200, "open when no password file"
+    PASSWORD_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PASSWORD_PATH.write_text("  s3cret \n", encoding="utf-8")  # whitespace stripped
+    try:
+        assert webapp._dashboard_password() == "s3cret"
+        assert client.get("/").status_code == 401, "protected once the file exists"
+        assert client.get("/api/speakers").status_code == 401
+        hdr = lambda u, p: {"Authorization": "Basic " + base64.b64encode(f"{u}:{p}".encode()).decode()}
+        assert client.get("/", headers=hdr("x", "s3cret")).status_code == 200
+        assert client.get("/", headers=hdr("x", "nope")).status_code == 401
+        assert client.get("/stream/RINCON_X.wav", headers=hdr("x", "nope")).status_code != 401, \
+            "stream endpoint must stay open for Sonos"
+    finally:
+        PASSWORD_PATH.unlink()
+    assert webapp._dashboard_password() is None, "removing the file re-opens the dashboard"
+    print("  dashboard password OK (open by default, enforced when set)")
+
+
+_test_dashboard_password()
+
 print("[test] watchdog restarts dropped streams, respects other sources + cooldown...")
 import sonos_ctl  # noqa: E402
 

--- a/tray_icon.py
+++ b/tray_icon.py
@@ -4,12 +4,28 @@ import webbrowser
 import pystray
 from PIL import Image, ImageDraw
 
+# Set once the tray icon is live, so other threads (main.announce_startup)
+# can pop a startup balloon without threading an icon reference around.
+_icon = None
+
 
 def make_image():
     img = Image.new("RGB", (64, 64), "black")
     d = ImageDraw.Draw(img)
     d.ellipse((8, 8, 56, 56), fill=(29, 185, 84))
     return img
+
+
+def notify(message, title="PC2Sonos"):
+    """Best-effort tray balloon. No-op if the tray isn't up or the
+    platform backend doesn't support notifications."""
+    icon = _icon
+    if icon is None:
+        return
+    try:
+        icon.notify(message, title)
+    except Exception:
+        pass
 
 
 def run_tray(config):
@@ -69,5 +85,7 @@ def run_tray(config):
         pystray.MenuItem("Export Diagnostics...", export_diagnostics),
         pystray.MenuItem("Quit PC2Sonos", quit_app),
     )
+    global _icon
     icon = pystray.Icon("pc2sonos", make_image(), "PC2Sonos", menu)
+    _icon = icon
     icon.run()

--- a/webapp.py
+++ b/webapp.py
@@ -2,16 +2,64 @@
 
 import io
 import queue
+import secrets
 import struct
 import time
 
 from flask import Flask, Response, jsonify, render_template_string, request
 
 from audio_engine import CHUNK, broadcaster, list_output_devices, restart_render, get_current_render_device_name, get_lan_ip
-from config import config, save_config
+from config import config, save_config, PASSWORD_PATH
 from sonos_ctl import speaker_mgr
 
 app = Flask(__name__)
+
+# (password_text, mtime_ns) cache so we re-read dashboard_password.txt only
+# when it actually changes -- create/edit the file and the next request
+# picks it up, no restart.
+_pw_cache = (None, None)
+
+
+def _dashboard_password():
+    """The current dashboard password, or None if the dashboard is open.
+
+    Open (None) when PASSWORD_PATH doesn't exist or is blank -- this is
+    the default: the app works on a trusted LAN with no setup, and
+    someone who wants a password just drops one line of text in that
+    file (path logged at startup)."""
+    global _pw_cache
+    try:
+        mtime = PASSWORD_PATH.stat().st_mtime_ns
+    except OSError:
+        _pw_cache = (None, None)
+        return None
+    if mtime != _pw_cache[1]:
+        try:
+            _pw_cache = (PASSWORD_PATH.read_text(encoding="utf-8").strip() or None, mtime)
+        except OSError:
+            _pw_cache = (None, None)
+    return _pw_cache[0]
+
+
+@app.before_request
+def require_auth():
+    # The stream endpoint is fetched directly by Sonos speakers, which
+    # can't respond to an HTTP auth challenge -- leave it open, same as
+    # every other PC->Sonos streamer. Everything else (the dashboard +
+    # /api/*) requires the password IF one has been configured.
+    if request.path.startswith("/stream/"):
+        return
+    password = _dashboard_password()
+    if password is None:
+        return
+    auth = request.authorization
+    given = auth.password if auth and auth.password is not None else ""
+    # compare as bytes -- str compare_digest raises on non-ASCII input
+    if not secrets.compare_digest(given.encode("utf-8"), password.encode("utf-8")):
+        return Response(
+            "Authentication required", 401,
+            {"WWW-Authenticate": 'Basic realm="PC2Sonos"'}
+        )
 
 # PC2Sonos is free. This is a "pay what you want" link for anyone who
 # finds it useful and wants to support development -- nothing in the app
@@ -510,4 +558,9 @@ def stream_wav(uid):
 
 def run_web(host="0.0.0.0", port=None):
     port = port or config["http_port"]
+    if _dashboard_password() is None:
+        print(f"[web] dashboard has no password. To set one, put it on a "
+              f"single line in: {PASSWORD_PATH}")
+    else:
+        print("[web] dashboard is password-protected")
     app.run(host=host, port=port, threaded=True, use_reloader=False)

--- a/webapp.py
+++ b/webapp.py
@@ -257,7 +257,8 @@ async function rescan(){
   try {
     const res = await fetch('/api/rescan', {method:'POST'});
     const data = await res.json();
-    el.textContent = 'Found ' + data.found + ' speaker' + (data.found === 1 ? '' : 's') + '.';
+    el.textContent = 'Found ' + data.found + ' speaker' + (data.found === 1 ? '' : 's') + '.'
+      + (data.ok ? '' : ' (a scan step hit an error -- see the log)');
   } catch (e) {
     el.textContent = 'Scan failed: ' + e;
   }
@@ -281,9 +282,12 @@ async function saveSeedIps(){
   const ips = raw.split(',').map(s => s.trim()).filter(Boolean);
   const res = await fetch('/api/sonos_seed', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({seed_ips: ips})});
   const data = await res.json();
-  el.textContent = data.ok
-    ? ('Saved. Speakers found so far: ' + data.found)
-    : ('Failed: ' + (data.error || 'unknown error'));
+  if (data.error) {
+    el.textContent = 'Failed: ' + data.error;
+  } else {
+    el.textContent = 'Saved. Speakers found so far: ' + data.found
+      + (data.ok ? '' : ' (a scan step hit an error -- see the log)');
+  }
   refresh();
 }
 async function toggle(uid, enabled){
@@ -462,11 +466,11 @@ def api_sonos_seed():
         return jsonify({"ok": False, "error": "seed_ips must be a list"}), 400
     config["sonos_seed_ips"] = [str(ip).strip() for ip in ips if str(ip).strip()]
     save_config(config)
-    try:
-        speaker_mgr.rediscover()
-    except Exception as e:
-        return jsonify({"ok": False, "error": f"{type(e).__name__}: {e}"}), 500
-    return jsonify({"ok": True, "found": len(speaker_mgr.list())})
+    # rediscover() swallows its own errors and reports success/failure via
+    # its return value -- pass that straight through rather than always
+    # claiming ok
+    ok = speaker_mgr.rediscover()
+    return jsonify({"ok": ok, "found": len(speaker_mgr.list())})
 
 
 @app.route("/api/rescan", methods=["POST"])
@@ -474,11 +478,8 @@ def api_rescan():
     """One immediate discovery pass. Useful in auto mode (skip the wait
     for the next 15s tick) and required in on_demand mode (the background
     loop is idle until asked)."""
-    try:
-        speaker_mgr.request_rescan()
-    except Exception as e:
-        return jsonify({"ok": False, "error": f"{type(e).__name__}: {e}"}), 500
-    return jsonify({"ok": True, "found": len(speaker_mgr.list())})
+    ok = speaker_mgr.request_rescan()
+    return jsonify({"ok": ok, "found": len(speaker_mgr.list())})
 
 
 @app.route("/api/default_speaker", methods=["POST"])

--- a/webapp.py
+++ b/webapp.py
@@ -156,8 +156,16 @@ DASHBOARD_HTML = """
 </div>
 
 <div class="card">
-  <label style="margin-bottom:0;">Sonos speakers</label>
+  <div style="display:flex; align-items:center; justify-content:space-between;">
+    <label style="margin-bottom:0;">Sonos speakers</label>
+    <button onclick="rescan()" style="background:#333; color:#eee; font-weight:400; padding:4px 10px; font-size:12px;">Rescan</button>
+  </div>
+  <div style="font-size:11px; color:#777; margin:2px 0 8px;">
+    &#9733; = default speaker: streamed to the instant PC2Sonos starts, before
+    a network scan finishes. Click a star to set it.
+  </div>
   <div id="speakers"></div>
+  <div id="rescanResult" style="margin-top:6px; font-size:12px; color:#888;"></div>
   <details style="margin-top:12px; font-size:12px; color:#aaa;">
     <summary style="cursor:pointer; color:#ccc;">Speakers not showing up? (different subnet / IoT VLAN)</summary>
     <div style="margin-top:10px; line-height:1.5;">
@@ -229,7 +237,11 @@ async function refresh(){
     const div = document.createElement('div');
     div.className = 'speaker';
     const grouped = s.grouped_with && s.grouped_with.length;
+    const star = s.is_default ? '&#9733;' : '&#9734;';
+    const starTitle = s.is_default ? 'Default speaker (click to unset)' : 'Set as default speaker';
     div.innerHTML = `
+      <span onclick="setDefault('${s.uid}', ${s.is_default})" title="${starTitle}"
+            style="cursor:pointer; font-size:16px; color:${s.is_default ? '#f5c518' : '#666'};">${star}</span>
       <input type="checkbox" class="toggle" ${s.enabled ? 'checked' : ''} onchange="toggle('${s.uid}', this.checked)">
       <span class="name">${s.name}${grouped ? ` <span style="font-weight:400; color:#888; font-size:12px;">(grouped with ${s.grouped_with.join(', ')} &mdash; this also controls them)</span>` : ''}</span>
       <input type="range" min="0" max="100" value="${s.volume}" onchange="setVol('${s.uid}', this.value)">
@@ -238,6 +250,23 @@ async function refresh(){
     `;
     el.appendChild(div);
   });
+}
+async function rescan(){
+  const el = document.getElementById('rescanResult');
+  el.textContent = 'Scanning the network...';
+  try {
+    const res = await fetch('/api/rescan', {method:'POST'});
+    const data = await res.json();
+    el.textContent = 'Found ' + data.found + ' speaker' + (data.found === 1 ? '' : 's') + '.';
+  } catch (e) {
+    el.textContent = 'Scan failed: ' + e;
+  }
+  refresh();
+}
+async function setDefault(uid, isDefault){
+  await fetch('/api/default_speaker', {method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({uid: isDefault ? null : uid})});
+  refresh();
 }
 async function loadSeedIps(){
   const res = await fetch('/api/sonos_seed');
@@ -438,6 +467,29 @@ def api_sonos_seed():
     except Exception as e:
         return jsonify({"ok": False, "error": f"{type(e).__name__}: {e}"}), 500
     return jsonify({"ok": True, "found": len(speaker_mgr.list())})
+
+
+@app.route("/api/rescan", methods=["POST"])
+def api_rescan():
+    """One immediate discovery pass. Useful in auto mode (skip the wait
+    for the next 15s tick) and required in on_demand mode (the background
+    loop is idle until asked)."""
+    try:
+        speaker_mgr.request_rescan()
+    except Exception as e:
+        return jsonify({"ok": False, "error": f"{type(e).__name__}: {e}"}), 500
+    return jsonify({"ok": True, "found": len(speaker_mgr.list())})
+
+
+@app.route("/api/default_speaker", methods=["POST"])
+def api_default_speaker():
+    """Pin the speaker PC2Sonos streams to immediately at launch (by its
+    current IP), or clear it with {"uid": null}."""
+    data = request.get_json(force=True)
+    uid = data.get("uid")
+    if speaker_mgr.set_default_speaker(uid):
+        return jsonify({"ok": True})
+    return jsonify({"ok": False, "error": "no known IP for that speaker yet"}), 400
 
 
 @app.route("/api/speaker/<uid>/volume", methods=["POST"])

--- a/webapp.py
+++ b/webapp.py
@@ -110,6 +110,23 @@ DASHBOARD_HTML = """
 <div class="card">
   <label style="margin-bottom:0;">Sonos speakers</label>
   <div id="speakers"></div>
+  <details style="margin-top:12px; font-size:12px; color:#aaa;">
+    <summary style="cursor:pointer; color:#ccc;">Speakers not showing up? (different subnet / IoT VLAN)</summary>
+    <div style="margin-top:10px; line-height:1.5;">
+      Automatic discovery uses network multicast, which most routers don't
+      pass between VLANs. If your Sonos speakers are on a separate (e.g.
+      IoT) network, type <strong>one speaker's IP address</strong> below &mdash;
+      the app will reach it directly and find the rest from it. Give that
+      speaker a DHCP reservation so its IP doesn't change. Comma-separate
+      to list more than one.
+      <div style="display:flex; gap:8px; margin-top:8px; flex-wrap:wrap;">
+        <input type="text" id="seedIps" placeholder="10.0.20.41, 10.0.20.42"
+               style="flex:1; min-width:180px; padding:6px; background:#111; color:#eee; border:1px solid #333; border-radius:6px;">
+        <button onclick="saveSeedIps()">Save &amp; scan</button>
+      </div>
+      <div id="seedResult" style="margin-top:8px; color:#888;"></div>
+    </div>
+  </details>
 </div>
 
 <div class="card">
@@ -173,6 +190,24 @@ async function refresh(){
     `;
     el.appendChild(div);
   });
+}
+async function loadSeedIps(){
+  const res = await fetch('/api/sonos_seed');
+  const data = await res.json();
+  const el = document.getElementById('seedIps');
+  if (document.activeElement !== el) el.value = (data.seed_ips || []).join(', ');
+}
+async function saveSeedIps(){
+  const el = document.getElementById('seedResult');
+  el.textContent = 'Saving and looking for speakers...';
+  const raw = document.getElementById('seedIps').value;
+  const ips = raw.split(',').map(s => s.trim()).filter(Boolean);
+  const res = await fetch('/api/sonos_seed', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({seed_ips: ips})});
+  const data = await res.json();
+  el.textContent = data.ok
+    ? ('Saved. Speakers found so far: ' + data.found)
+    : ('Failed: ' + (data.error || 'unknown error'));
+  refresh();
 }
 async function toggle(uid, enabled){
   await fetch('/api/speaker/' + uid + '/enabled', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({enabled})});
@@ -273,6 +308,7 @@ async function checkDonatePrompt(){
 }
 refresh();
 loadDevices();
+loadSeedIps();
 checkDonatePrompt();
 setInterval(refresh, 4000);
 </script>
@@ -333,6 +369,27 @@ def api_set_enabled(uid):
     base_url = f"http://{get_lan_ip()}:{config['http_port']}"
     speaker_mgr.set_enabled(uid, bool(data.get("enabled")), base_url)
     return jsonify({"ok": True})
+
+
+@app.route("/api/sonos_seed", methods=["GET", "POST"])
+def api_sonos_seed():
+    """Manual speaker IPs for when the speakers are on a subnet SSDP
+    multicast can't cross (e.g. an IoT VLAN). Saving triggers an
+    immediate rediscover so the user sees the result without waiting for
+    the 15s loop."""
+    if request.method == "GET":
+        return jsonify({"seed_ips": config.get("sonos_seed_ips", [])})
+    data = request.get_json(force=True)
+    ips = data.get("seed_ips", [])
+    if not isinstance(ips, list):
+        return jsonify({"ok": False, "error": "seed_ips must be a list"}), 400
+    config["sonos_seed_ips"] = [str(ip).strip() for ip in ips if str(ip).strip()]
+    save_config(config)
+    try:
+        speaker_mgr.rediscover()
+    except Exception as e:
+        return jsonify({"ok": False, "error": f"{type(e).__name__}: {e}"}), 500
+    return jsonify({"ok": True, "found": len(speaker_mgr.list())})
 
 
 @app.route("/api/speaker/<uid>/volume", methods=["POST"])


### PR DESCRIPTION
Three related improvements, one commit each, plus a small `.gitignore` addition.

## Discover speakers on a different subnet / IoT VLAN

`soco.discovery.discover()` uses SSDP multicast, which routers don't forward between VLANs — so with the Sonos speakers on an IoT VLAN and the PC on the main LAN, the dashboard finds nothing even though unicast control works fine.

- New `sonos_seed_ips` / `sonos_scan_cidrs` config keys (both empty by default — SSDP stays the fast path on a flat network)
- `_discover_zones()`: SSDP first, then reach a configured seed IP directly (one reachable speaker yields the whole household via ZoneGroupTopology), then `scan_network()` over a CIDR
- `soco.config.REQUEST_TIMEOUT` 20s → 4s: there's no multicast liveness check on the unicast path, so one asleep speaker otherwise stalls every code path that touches it for 20s at a time
- `SpeakerManager.list()` no longer makes any network call — names and group membership are cached by the background discovery/watchdog threads. Before this, one offline speaker made `/api/speakers` hang then 500. Bonded Subs are filtered out of "grouped with".
- `get_lan_ip()` picks the source IP by the route to an actual speaker before falling back to the internet-facing NIC (matters on multi-NIC / VPN boxes, where the stream URL host was otherwise wrong)
- Dashboard: a "Speakers not showing up?" section to enter a seed IP; `POST /api/sonos_seed`
- Diagnostics snapshot reports the seed IPs / scan subnets / reachable speaker IPs

## Optional dashboard password

Off by default — PC2Sonos assumes it's on a network you control. Create `dashboard_password.txt` in the data folder (next to `config.json`) to require one; it takes effect on the next request, no restart.

- Kept in its own file, **not** `config.json`, on purpose: `config.json` is bundled verbatim into the diagnostics zip, so a password there would ride along in every support submission. The new file is git-ignored and never touched by diagnostics; the snapshot reports only "set" / "not set".
- `/stream/*.wav` stays open regardless — Sonos speakers can't answer an auth challenge.
- README is explicit that this is a low-effort gate (plain text, plain-HTTP base64), not encryption.

## Faster, quieter startup after a reboot

Previously the app waited out a full discovery pass (~15–20s) before any audio, and opened a browser tab on every login.

- `default_speaker_ip` / `default_speaker_uid`: reach one speaker directly at launch (`SoCo(ip).uid`, one unicast call) and register it so the watchdog boot-starts it immediately — first stream in ~2–3s. The uid is auto-recorded and used to notice if DHCP hands that IP to a different device. Dashboard: a per-row ★; `POST /api/default_speaker`.
- `discovery_mode: "on_demand"`: once the default speaker is up, stop the 15s background re-scan — one safety-net pass after audio is underway (to populate the dashboard with the other speakers), then only on request. New "Rescan" button + `POST /api/rescan`; `"auto"` keeps the 15s loop.
- `new_speakers_default_enabled` (default `true`, unchanged behavior): set `false` to have newly-discovered speakers stay off until enabled — useful on a busy / multi-household network. The default speaker is always enabled.
- `has_launched_before`: the dashboard auto-opens in the browser on the first run only; every launch after that fires a tray notification instead of stealing focus.
- `stream_keeper`'s first tick and the startup announce wait for the Flask port to actually accept connections rather than a fixed sleep.

## Refuse to start a second copy

Testing the reboot path turned up that Windows sometimes runs the Startup-folder shortcut twice (Explorer re-processing the folder when it restarts early in the session). Both copies bind the port (Windows allows two sockets to share one with `SO_REUSEADDR`), boot-start the same speaker, and run their own watchdogs against it.

`acquire_single_instance_lock()` takes a session-scoped named mutex as the first thing in `main()`, before anything touches the HTTP port, capture device, or a speaker. A second instance logs one line and exits. Never raises; no-op off Windows.

## Tests

`test_logic.py` gains coverage for the seed-IP fallback, the password gate, `prime_default_speaker` (reachable / unreachable / uid-mismatch), `new_speakers_default_enabled`, and the on_demand discovery loop. It also fixes a pre-existing hygiene bug where the watchdog test persisted fake `RINCON_*` speakers into the real `config.json`.

Two unrelated failures already present in `test_logic.py` are left untouched: an `assert "not Windows" in snap` that only holds off-Windows, and `calibration.run_calibration` (renamed in the code but not the test).
